### PR TITLE
Use ssl certificates if available

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ module.exports = function (pluginConfig, {pkg, npm, plugins, options}, cb) {
   npmlog.level = npm.loglevel || 'warn'
   let clientConfig = {log: npmlog}
   if (npm.cafile && fs.existsSync(npm.cafile)) {
-    clientConfig.ssl = {ca: fs.readFileSync(npm.cafile, 'utf-8')};
+    clientConfig.ssl = {ca: fs.readFileSync(npm.cafile, 'utf-8')}
   }
   // disable retries for tests
   if (pluginConfig && pluginConfig.retry) clientConfig.retry = pluginConfig.retry

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import fs from 'fs'
 import SemanticReleaseError from '@semantic-release/error'
 import RegClient from 'npm-registry-client'
 import npmlog from 'npmlog'
@@ -5,6 +6,9 @@ import npmlog from 'npmlog'
 module.exports = function (pluginConfig, {pkg, npm, plugins, options}, cb) {
   npmlog.level = npm.loglevel || 'warn'
   let clientConfig = {log: npmlog}
+  if (npm.cafile && fs.existsSync(npm.cafile)) {
+    clientConfig.ssl = {ca: fs.readFileSync(npm.cafile, 'utf-8')};
+  }
   // disable retries for tests
   if (pluginConfig && pluginConfig.retry) clientConfig.retry = pluginConfig.retry
   const client = new RegClient(clientConfig)


### PR DESCRIPTION
Using custom SSL certificates allow semantic-release to be used in environments with self-signed certificates.

See also https://github.com/semantic-release/semantic-release/pull/227
