### PR TITLE
NPM unpublish artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "@semantic-release/error": "^1.0.0",
     "npm-registry-client": "^7.0.1",
-    "npmlog": "^2.0.0"
+    "npmlog": "^2.0.0",
+    "semver": "^5.3.0"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",
@@ -28,7 +29,6 @@
     "nyc": "^6.4.4",
     "rimraf": "^2.4.2",
     "semantic-release": "^4.0.3",
-    "semver": "^5.2.0",
     "standard": "^7.1.1",
     "tap": "^5.4.2"
   },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "nyc": "^6.4.4",
     "rimraf": "^2.4.2",
     "semantic-release": "^4.0.3",
+    "semver": "^5.2.0",
     "standard": "^7.1.1",
     "tap": "^5.4.2"
   },

--- a/test/mocks/registry.js
+++ b/test/mocks/registry.js
@@ -24,10 +24,18 @@ const availableModule = {
 module.exports = nock('http://registry.npmjs.org')
   .get('/available')
   .reply(200, availableModule)
-  .get('/unpublished')
+  .get('/unpublishedSingle')
   .reply(200, () => {
     let response = availableModule
     response.time['1.33.8'] = '2016-07-13T03:36:36.168Z'
+
+    return response
+  })
+  .get('/unpublishedMultiple')
+  .reply(200, () => {
+    let response = availableModule
+    response.time['1.33.8'] = '2016-07-13T03:36:36.168Z'
+    response.time['1.33.9'] = '2016-07-13T03:38:38.168Z'
 
     return response
   })

--- a/test/mocks/registry.js
+++ b/test/mocks/registry.js
@@ -12,12 +12,25 @@ const availableModule = {
     '1.33.7': {
       gitHead: 'HEAD'
     }
+  },
+  time: {
+    'modified': '2016-07-13T22:49:38.007Z',
+    'created': '2016-07-07T03:03:29.358Z',
+    '0.8.15': '2016-07-13T01:36:31.145Z',
+    '1.33.7': '2016-07-13T03:34:34.168Z'
   }
 }
 
 module.exports = nock('http://registry.npmjs.org')
   .get('/available')
   .reply(200, availableModule)
+  .get('/unpublished')
+  .reply(200, () => {
+    let response = availableModule
+    response.time['1.33.8'] = '2016-07-13T03:36:36.168Z'
+
+    return response
+  })
   .get('/tagged')
   .times(2)
   .reply(200, availableModule)

--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -11,7 +11,7 @@ const npm = {
 }
 
 test('last release from registry', (t) => {
-  t.plan(7)
+  t.plan(8)
 
   t.test('get release from package name', (tt) => {
     lastRelease({}, {
@@ -122,13 +122,27 @@ test('last release from registry', (t) => {
     })
   })
 
-  t.test('get release from unpublished package', (tt) => {
+  t.test('get release from package with a single unpublished version', (tt) => {
     lastRelease({}, {
-      pkg: {name: 'unpublished'},
+      pkg: {name: 'unpublishedSingle'},
       npm
     }, (err, release) => {
       tt.error(err)
       tt.is(release.version, '1.33.8', 'version')
+      tt.is(release.gitHead, 'HEAD', 'gitHead')
+      tt.is(release.tag, 'latest', 'dist-tag')
+
+      tt.end()
+    })
+  })
+
+  t.test('get release from package with multiple unpublished versions', (tt) => {
+    lastRelease({}, {
+      pkg: {name: 'unpublishedMultiple'},
+      npm
+    }, (err, release) => {
+      tt.error(err)
+      tt.is(release.version, '1.33.9', 'version')
       tt.is(release.gitHead, 'HEAD', 'gitHead')
       tt.is(release.tag, 'latest', 'dist-tag')
 

--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -11,7 +11,7 @@ const npm = {
 }
 
 test('last release from registry', (t) => {
-  t.plan(6)
+  t.plan(7)
 
   t.test('get release from package name', (tt) => {
     lastRelease({}, {
@@ -119,6 +119,20 @@ test('last release from registry', (t) => {
         ttt.is(release.version, undefined, 'no version')
         ttt.end()
       })
+    })
+  })
+
+  t.test('get release from unpublished package', (tt) => {
+    lastRelease({}, {
+      pkg: {name: 'unpublished'},
+      npm
+    }, (err, release) => {
+      tt.error(err)
+      tt.is(release.version, '1.33.8', 'version')
+      tt.is(release.gitHead, 'HEAD', 'gitHead')
+      tt.is(release.tag, 'latest', 'dist-tag')
+
+      tt.end()
     })
   })
 })


### PR DESCRIPTION
Running `npm unpublish` will leave behind a version lock inside `response.time` which was not mocked by the test suite. 
This change enables semantic-release to properly identify the latest released version, enabling semantic-release to publish without any other modification to the configuration
