### PR TITLE
fix(last-release-npm): properly handle completely unpublished packages

### DIFF
--- a/test/mocks/registry.js
+++ b/test/mocks/registry.js
@@ -15,6 +15,16 @@ const availableModule = {
   }
 }
 
+const completelyUnpublishedModule = {
+  name: 'i-am-completely-unpublished',
+  time: {
+    '2.0.0': '2016-12-01T17:50:30.699Z',
+    unpublished: {
+      time: '2016-12-01T17:53:45.940Z'
+    }
+  }
+}
+
 module.exports = nock('http://registry.npmjs.org')
   .get('/available')
   .reply(200, availableModule)
@@ -25,6 +35,8 @@ module.exports = nock('http://registry.npmjs.org')
   .reply(200, availableModule)
   .get('/@scoped%2Favailable')
   .reply(200, availableModule)
+  .get('/completely-unpublished')
+  .reply(200, completelyUnpublishedModule)
   .get('/unavailable')
   .reply(404, {})
   .get('/unavailable-no-body')

--- a/test/specs/index.js
+++ b/test/specs/index.js
@@ -11,7 +11,7 @@ const npm = {
 }
 
 test('last release from registry', (t) => {
-  t.plan(6)
+  t.plan(7)
 
   t.test('get release from package name', (tt) => {
     lastRelease({}, {
@@ -81,6 +81,17 @@ test('last release from registry', (t) => {
       tt.is(release.gitHead, 'HEAD', 'gitHead')
       tt.is(release.tag, 'latest', 'dist-tag')
 
+      tt.end()
+    })
+  })
+
+  t.test('get nothing from completely unpublished package name', (tt) => {
+    lastRelease({}, {
+      pkg: {name: 'completely-unpublished'},
+      npm
+    }, (err, release) => {
+      tt.error(err)
+      tt.is(release.version, undefined, 'no version')
       tt.end()
     })
   })


### PR DESCRIPTION
currently, the script fails on the packages that were completely removed from a registry (all the versions are unpublished). It happens because npmRegistryClient returns non-empty package `data`, but it doesn't contain `dist-tags` property.

This issue is quite important because it also breaks other packages that depend on this one, like [lerna-semantic-release](https://github.com/atlassian/lerna-semantic-release)