### PR TITLE
Accept registry URL with or without a trailing slash

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const {promisify} = require('util');
+const {resolve} = require('url');
 const SemanticReleaseError = require('@semantic-release/error');
 const RegClient = require('npm-registry-client');
 const npmlog = require('npmlog');
@@ -7,7 +8,7 @@ module.exports = async function({retry} = {}, {pkg, npm, options}, cb) {
   npmlog.level = npm.loglevel || 'warn';
   const client = new RegClient({log: npmlog, retry});
   try {
-    const data = await promisify(client.get.bind(client))(`${npm.registry}${pkg.name.replace('/', '%2F')}`, {
+    const data = await promisify(client.get.bind(client))(resolve(npm.registry, pkg.name.replace('/', '%2F')), {
       auth: npm.auth,
     });
     if (data && !data['dist-tags']) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -134,3 +134,17 @@ test.serial('Accept an undefined "pluginConfig"', async t => {
   t.is(release.tag, 'latest');
   t.true(registry.isDone());
 });
+
+test.serial('Handle missing trailing slash on registry URL', async t => {
+  const name = 'available';
+  const registry = available(name);
+  const release = await promisify(lastRelease)(
+    {},
+    {pkg: {name}, npm: defaults({registry: 'http://registry.npmjs.org'}, npm)}
+  );
+
+  t.is(release.version, '1.33.7');
+  t.is(release.gitHead, 'HEAD');
+  t.is(release.tag, 'latest');
+  t.true(registry.isDone());
+});


### PR DESCRIPTION
NPM registry is configured by default to `http://registry.npmjs.org/` but one might configure `http://registry.npmjs.org` or any other URL without a trailing `/`.

Use native Node [URL](https://nodejs.org/api/url.html#url_url) to concat the registry URL and the package name.